### PR TITLE
android 7 build path changes

### DIFF
--- a/scripts/after-prepare.js
+++ b/scripts/after-prepare.js
@@ -20,7 +20,7 @@ function run() {
         throw("Failed to load dependencies. If using cordova@6 CLI, ensure this plugin is installed with the --fetch option: " + e.toString());
     }
 
-    const GRADLE_FILENAME = path.resolve(process.cwd(), 'platforms', 'android', 'build.gradle');
+    const GRADLE_FILENAME = path.resolve(process.cwd(), 'platforms', 'android', 'app', 'build.gradle');
     const PACKAGE_PATTERN = /(compile "com.google.android.gms:[^:]+:)([^"]+)"/;
 
     var data = fs.readFileSync(path.resolve(process.cwd(), 'config.xml'));

--- a/scripts/before-prepare.js
+++ b/scripts/before-prepare.js
@@ -20,7 +20,7 @@ function run() {
         throw("Failed to load dependencies. If using cordova@6 CLI, ensure this plugin is installed with the --fetch option: " + e.toString());
     }
 
-    const GRADLE_FILENAME = path.resolve(process.cwd(), 'platforms', 'android', PLUGIN_NAME, 'properties.gradle');
+    const GRADLE_FILENAME = path.resolve(process.cwd(), 'platforms', 'android', 'app', PLUGIN_NAME, 'properties.gradle');
     const PROPERTIES_TEMPLATE = 'ext {PLAY_SERVICES_VERSION = "<VERSION>"}';
 
     var data = fs.readFileSync(path.resolve(process.cwd(), 'config.xml'));


### PR DESCRIPTION
Change gradle path reference inside scripts/after_prepare.js to reflect changes in cordova android 7 to build folder structures. 

Essentially `<project-root>/platforms/android/app/build.gradle` is the file that has all the dependencies added in by various cordova plugins. 

And `properties.gradle` from this plugin is located at `<proj root>/platforms/android/app/cordova-android-play-services-gradle-release/properties.gradle`

You may want to tag your current release before merging this PR. 


## PR Type
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->
