### PR TITLE
Update apply-changes.js

### DIFF
--- a/scripts/apply-changes.js
+++ b/scripts/apply-changes.js
@@ -1,7 +1,7 @@
 const PLUGIN_NAME = "cordova-android-play-services-gradle-release";
 const V6 = "cordova-android@6";
 const V7 = "cordova-android@7";
-const PACKAGE_PATTERN = /(compile "com.google.android.gms:[^:]+:)([^"]+)"/;
+const PACKAGE_PATTERN = /(compile "com.google.android.gms:[^:]+:)([^"]+)"/g;
 const PROPERTIES_TEMPLATE = 'ext {PLAY_SERVICES_VERSION = "<VERSION>"}';
 
 var FILE_PATHS = {};


### PR DESCRIPTION
The regex replace of the library version was only matching a single occurrence. 
When a build.gradle looks like the following: Only one line was getting modified.
    compile "com.google.android.gms:play-services-base:11.0.4"
    compile "com.google.android.gms:play-services-ads:11.0.4"

The proposed change would modify both.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [ ] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

## Does this PR introduce a breaking change?
- [ ] Yes
- [x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information